### PR TITLE
update blockstack.js to 18.2.1

### DIFF
--- a/node_modules/blockstack/CHANGELOG.md
+++ b/node_modules/blockstack/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [18.2.1] - 2018-01-08
+
+### Added
+
+- Added automatic retry logic to `putFile` in the case of a failed storage call. This might be
+the case if there have been any token revokations. This new logic will catch the first failed write,
+construct (and cache) a new Gaia token, and then attempt the write again. This allows tokens
+to be revoked without any hiccups from a user experience standpoint.
+
 ## [18.2.0] - 2018-12-20
 
 ### Added

--- a/node_modules/blockstack/README.md
+++ b/node_modules/blockstack/README.md
@@ -66,7 +66,7 @@ functionality so that we can make sure your contribution can be included!
 
 ## Maintainer
 
-This repository is maintained by [larry.id](https://explorer.blockstack.org/name/larry.id).
+This repository is maintained by [yukan.id](https://explorer.blockstack.org/name/yukan.id).
 
 ## Testing
 

--- a/node_modules/blockstack/dist/blockstack.js
+++ b/node_modules/blockstack/dist/blockstack.js
@@ -2328,6 +2328,7 @@ var BlockstackNetwork = exports.BlockstackNetwork = function () {
     this.DUST_MINIMUM = 5500;
     this.includeUtxoMap = {};
     this.excludeUtxoSet = [];
+    this.MAGIC_BYTES = 'id';
   }
 
   _createClass(BlockstackNetwork, [{
@@ -4059,6 +4060,15 @@ function makeTXbuilder() {
   return txb;
 }
 
+function opEncode(opcode) {
+  // NOTE: must *always* a 3-character string
+  var res = '' + _config.config.network.MAGIC_BYTES + opcode;
+  if (res.length !== 3) {
+    throw new Error('Runtime error: invalid MAGIC_BYTES');
+  }
+  return res;
+}
+
 function makePreorderSkeleton(fullyQualifiedName, consensusHash, preorderAddress, burnAddress, burn) {
   var registerAddress = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : null;
 
@@ -4095,7 +4105,7 @@ function makePreorderSkeleton(fullyQualifiedName, consensusHash, preorderAddress
 
   var opReturnBufferLen = burnAmount.units === 'BTC' ? 39 : 66;
   var opReturnBuffer = Buffer.alloc(opReturnBufferLen);
-  opReturnBuffer.write('id?', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('?'), 0, 3, 'ascii');
   hashed.copy(opReturnBuffer, 3);
   opReturnBuffer.write(consensusHash, 23, 16, 'hex');
 
@@ -4183,7 +4193,7 @@ function makeRegisterSkeleton(fullyQualifiedName, ownerAddress) {
     payload = Buffer.from(fullyQualifiedName, 'ascii');
   }
 
-  var opReturnBuffer = Buffer.concat([Buffer.from('id:', 'ascii'), payload]);
+  var opReturnBuffer = Buffer.concat([Buffer.from(opEncode(':'), 'ascii'), payload]);
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
   var tx = makeTXbuilder();
 
@@ -4264,7 +4274,7 @@ function makeTransferSkeleton(fullyQualifiedName, consensusHash, newOwner) {
     keepChar = '>';
   }
 
-  opRet.write('id>', 0, 3, 'ascii');
+  opRet.write(opEncode('>'), 0, 3, 'ascii');
   opRet.write(keepChar, 3, 1, 'ascii');
 
   var hashed = (0, _utils.hash128)(Buffer.from(fullyQualifiedName, 'ascii'));
@@ -4305,7 +4315,7 @@ function makeUpdateSkeleton(fullyQualifiedName, consensusHash, valueHash) {
 
   var hashedName = (0, _utils.hash128)(Buffer.concat([nameBuff, consensusBuff]));
 
-  opRet.write('id+', 0, 3, 'ascii');
+  opRet.write(opEncode('+'), 0, 3, 'ascii');
   hashedName.copy(opRet, 3);
   opRet.write(valueHash, 19, 20, 'hex');
 
@@ -4337,7 +4347,7 @@ function makeRevokeSkeleton(fullyQualifiedName) {
 
   var nameBuff = Buffer.from(fullyQualifiedName, 'ascii');
 
-  opRet.write('id~', 0, 3, 'ascii');
+  opRet.write(opEncode('~'), 0, 3, 'ascii');
 
   var opReturnBuffer = Buffer.concat([opRet, nameBuff]);
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -4391,7 +4401,7 @@ function makeNamespacePreorderSkeleton(namespaceID, consensusHash, preorderAddre
   }
 
   var opReturnBuffer = Buffer.alloc(opReturnBufferLen);
-  opReturnBuffer.write('id*', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('*'), 0, 3, 'ascii');
   hashed.copy(opReturnBuffer, 3);
   opReturnBuffer.write(consensusHash, 23, 16, 'hex');
 
@@ -4426,7 +4436,7 @@ function makeNamespaceRevealSkeleton(namespace, revealAddress) {
   var hexPayload = namespace.toHexPayload();
 
   var opReturnBuffer = Buffer.alloc(3 + hexPayload.length / 2);
-  opReturnBuffer.write('id&', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('&'), 0, 3, 'ascii');
   opReturnBuffer.write(hexPayload, 3, hexPayload.length / 2, 'hex');
 
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -4447,7 +4457,7 @@ function makeNamespaceReadySkeleton(namespaceID) {
     output 0: namespace ready code
    */
   var opReturnBuffer = Buffer.alloc(3 + namespaceID.length + 1);
-  opReturnBuffer.write('id!', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('!'), 0, 3, 'ascii');
   opReturnBuffer.write('.' + namespaceID, 3, namespaceID.length + 1, 'ascii');
 
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -4474,7 +4484,7 @@ function makeNameImportSkeleton(name, recipientAddr, zonefileHash) {
 
   var network = _config.config.network;
   var opReturnBuffer = Buffer.alloc(3 + name.length);
-  opReturnBuffer.write('id;', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode(';'), 0, 3, 'ascii');
   opReturnBuffer.write(name, 3, name.length, 'ascii');
 
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -4502,7 +4512,7 @@ function makeAnnounceSkeleton(messageHash) {
   }
 
   var opReturnBuffer = Buffer.alloc(3 + messageHash.length / 2);
-  opReturnBuffer.write('id#', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('#'), 0, 3, 'ascii');
   opReturnBuffer.write(messageHash, 3, messageHash.length / 2, 'hex');
 
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -4540,7 +4550,7 @@ function makeTokenTransferSkeleton(recipientAddress, consensusHash, tokenType, t
 
   var tokenValueHexPadded = ('0000000000000000' + tokenValueHex).slice(-16);
 
-  opReturnBuffer.write('id$', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('$'), 0, 3, 'ascii');
   opReturnBuffer.write(consensusHash, 3, consensusHash.length / 2, 'hex');
   opReturnBuffer.write(tokenTypeHexPadded, 19, tokenTypeHexPadded.length / 2, 'hex');
   opReturnBuffer.write(tokenValueHexPadded, 38, tokenValueHexPadded.length / 2, 'hex');
@@ -8116,7 +8126,11 @@ function uploadToGaiaHub(filename, contents, hubConfig) {
     },
     body: contents
   }).then(function (response) {
-    return response.text();
+    if (response.ok) {
+      return response.text();
+    } else {
+      throw new Error('Error when uploading to Gaia hub');
+    }
   }).then(function (responseText) {
     return JSON.parse(responseText);
   }).then(function (responseJSON) {
@@ -8647,7 +8661,13 @@ function putFile(path, content, options) {
     var signatureObject = (0, _encryption.signECDSA)(privateKey, content);
     var signatureContent = JSON.stringify(signatureObject);
     return (0, _hub.getOrSetLocalGaiaHubConnection)().then(function (gaiaHubConfig) {
-      return Promise.all([(0, _hub.uploadToGaiaHub)(path, content, gaiaHubConfig, contentType), (0, _hub.uploadToGaiaHub)('' + path + SIGNATURE_FILE_SUFFIX, signatureContent, gaiaHubConfig, 'application/json')]);
+      return new Promise(function (resolve, reject) {
+        return Promise.all([(0, _hub.uploadToGaiaHub)(path, content, gaiaHubConfig, contentType), (0, _hub.uploadToGaiaHub)('' + path + SIGNATURE_FILE_SUFFIX, signatureContent, gaiaHubConfig, 'application/json')]).then(resolve).catch(function () {
+          (0, _hub.setLocalGaiaHubConnection)().then(function (freshHubConfig) {
+            return Promise.all([(0, _hub.uploadToGaiaHub)(path, content, freshHubConfig, contentType), (0, _hub.uploadToGaiaHub)('' + path + SIGNATURE_FILE_SUFFIX, signatureContent, freshHubConfig, 'application/json')]).then(resolve).catch(reject);
+          });
+        });
+      });
     }).then(function (fileUrls) {
       return fileUrls[0];
     });
@@ -8669,7 +8689,13 @@ function putFile(path, content, options) {
     contentType = 'application/json';
   }
   return (0, _hub.getOrSetLocalGaiaHubConnection)().then(function (gaiaHubConfig) {
-    return (0, _hub.uploadToGaiaHub)(path, content, gaiaHubConfig, contentType);
+    return new Promise(function (resolve, reject) {
+      (0, _hub.uploadToGaiaHub)(path, content, gaiaHubConfig, contentType).then(resolve).catch(function () {
+        (0, _hub.setLocalGaiaHubConnection)().then(function (freshHubConfig) {
+          return (0, _hub.uploadToGaiaHub)(path, content, freshHubConfig, contentType).then(resolve).catch(reject);
+        });
+      });
+    });
   });
 }
 
@@ -8755,7 +8781,7 @@ function listFilesLoop(hubConfig, page, callCount, fileCount, callback) {
       return listFilesLoop(hubConfig, nextPage, callCount + 1, fileCount + entries.length, callback);
     } else {
       // no more entries -- end of data
-      return Promise.resolve(fileCount);
+      return Promise.resolve(fileCount + entries.length);
     }
   });
 }

--- a/node_modules/blockstack/docs.json
+++ b/node_modules/blockstack/docs.json
@@ -14796,7 +14796,7 @@
           "column": 0
         },
         "end": {
-          "line": 441,
+          "line": 460,
           "column": 1
         }
       },
@@ -16262,22 +16262,22 @@
     ],
     "loc": {
       "start": {
-        "line": 443,
+        "line": 462,
         "column": 0
       },
       "end": {
-        "line": 449,
+        "line": 468,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 450,
+          "line": 469,
           "column": 0
         },
         "end": {
-          "line": 452,
+          "line": 471,
           "column": 1
         }
       },
@@ -17043,22 +17043,22 @@
     ],
     "loc": {
       "start": {
-        "line": 224,
+        "line": 227,
         "column": 2
       },
       "end": {
-        "line": 232,
+        "line": 235,
         "column": 5
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 233,
+          "line": 236,
           "column": 2
         },
         "end": {
-          "line": 237,
+          "line": 240,
           "column": 3
         }
       },
@@ -17300,22 +17300,22 @@
     ],
     "loc": {
       "start": {
-        "line": 239,
+        "line": 242,
         "column": 2
       },
       "end": {
-        "line": 247,
+        "line": 250,
         "column": 5
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 248,
+          "line": 251,
           "column": 2
         },
         "end": {
-          "line": 252,
+          "line": 255,
           "column": 3
         }
       },
@@ -17551,22 +17551,22 @@
     ],
     "loc": {
       "start": {
-        "line": 254,
+        "line": 257,
         "column": 2
       },
       "end": {
-        "line": 258,
+        "line": 261,
         "column": 5
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 259,
+          "line": 262,
           "column": 2
         },
         "end": {
-          "line": 261,
+          "line": 264,
           "column": 3
         }
       },
@@ -17736,22 +17736,22 @@
     ],
     "loc": {
       "start": {
-        "line": 263,
+        "line": 266,
         "column": 2
       },
       "end": {
-        "line": 267,
+        "line": 270,
         "column": 5
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 268,
+          "line": 271,
           "column": 2
         },
         "end": {
-          "line": 273,
+          "line": 276,
           "column": 3
         }
       },
@@ -17987,22 +17987,22 @@
     ],
     "loc": {
       "start": {
-        "line": 275,
+        "line": 278,
         "column": 2
       },
       "end": {
-        "line": 280,
+        "line": 283,
         "column": 5
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 281,
+          "line": 284,
           "column": 2
         },
         "end": {
-          "line": 304,
+          "line": 307,
           "column": 3
         }
       },
@@ -18238,22 +18238,22 @@
     ],
     "loc": {
       "start": {
-        "line": 306,
+        "line": 309,
         "column": 2
       },
       "end": {
-        "line": 311,
+        "line": 314,
         "column": 5
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 312,
+          "line": 315,
           "column": 2
         },
         "end": {
-          "line": 333,
+          "line": 336,
           "column": 3
         }
       },
@@ -18485,22 +18485,22 @@
     ],
     "loc": {
       "start": {
-        "line": 335,
+        "line": 338,
         "column": 2
       },
       "end": {
-        "line": 339,
+        "line": 342,
         "column": 5
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 340,
+          "line": 343,
           "column": 2
         },
         "end": {
-          "line": 364,
+          "line": 367,
           "column": 3
         }
       },
@@ -18736,22 +18736,22 @@
     ],
     "loc": {
       "start": {
-        "line": 366,
+        "line": 369,
         "column": 2
       },
       "end": {
-        "line": 371,
+        "line": 374,
         "column": 5
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 372,
+          "line": 375,
           "column": 2
         },
         "end": {
-          "line": 389,
+          "line": 392,
           "column": 3
         }
       },
@@ -18997,22 +18997,22 @@
     ],
     "loc": {
       "start": {
-        "line": 391,
+        "line": 394,
         "column": 2
       },
       "end": {
-        "line": 398,
+        "line": 401,
         "column": 5
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 399,
+          "line": 402,
           "column": 2
         },
         "end": {
-          "line": 418,
+          "line": 421,
           "column": 3
         }
       },
@@ -19319,22 +19319,22 @@
     ],
     "loc": {
       "start": {
-        "line": 421,
+        "line": 424,
         "column": 2
       },
       "end": {
-        "line": 427,
+        "line": 430,
         "column": 5
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 428,
+          "line": 431,
           "column": 2
         },
         "end": {
-          "line": 453,
+          "line": 456,
           "column": 3
         }
       },
@@ -19647,22 +19647,22 @@
     ],
     "loc": {
       "start": {
-        "line": 455,
+        "line": 458,
         "column": 2
       },
       "end": {
-        "line": 463,
+        "line": 466,
         "column": 5
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 464,
+          "line": 467,
           "column": 2
         },
         "end": {
-          "line": 488,
+          "line": 491,
           "column": 3
         }
       },
@@ -19959,22 +19959,22 @@
     ],
     "loc": {
       "start": {
-        "line": 490,
+        "line": 493,
         "column": 2
       },
       "end": {
-        "line": 495,
+        "line": 498,
         "column": 5
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 496,
+          "line": 499,
           "column": 2
         },
         "end": {
-          "line": 513,
+          "line": 516,
           "column": 3
         }
       },
@@ -20224,22 +20224,22 @@
     ],
     "loc": {
       "start": {
-        "line": 515,
+        "line": 518,
         "column": 2
       },
       "end": {
-        "line": 522,
+        "line": 525,
         "column": 5
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 523,
+          "line": 526,
           "column": 2
         },
         "end": {
-          "line": 545,
+          "line": 548,
           "column": 3
         }
       },
@@ -21153,22 +21153,22 @@
     ],
     "loc": {
       "start": {
-        "line": 537,
+        "line": 556,
         "column": 0
       },
       "end": {
-        "line": 542,
+        "line": 561,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 543,
+          "line": 562,
           "column": 0
         },
         "end": {
-          "line": 546,
+          "line": 565,
           "column": 1
         }
       },

--- a/node_modules/blockstack/docs/index.html
+++ b/node_modules/blockstack/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset='utf-8' />
-  <title>blockstack 18.2.0 | Documentation</title>
+  <title>blockstack 18.2.1 | Documentation</title>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' type='text/css' rel='stylesheet' />
   <link href='assets/style.css' type='text/css' rel='stylesheet' />
@@ -14,7 +14,7 @@
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>blockstack</h3>
-          <div class='mb1'><code>18.2.0</code></div>
+          <div class='mb1'><code>18.2.1</code></div>
           <input
             placeholder='Filter'
             id='filter-input'

--- a/node_modules/blockstack/lib/network.js
+++ b/node_modules/blockstack/lib/network.js
@@ -86,6 +86,7 @@ var BlockstackNetwork = exports.BlockstackNetwork = function () {
     this.DUST_MINIMUM = 5500;
     this.includeUtxoMap = {};
     this.excludeUtxoSet = [];
+    this.MAGIC_BYTES = 'id';
   }
 
   _createClass(BlockstackNetwork, [{

--- a/node_modules/blockstack/lib/operations/skeletons.js
+++ b/node_modules/blockstack/lib/operations/skeletons.js
@@ -177,6 +177,15 @@ function makeTXbuilder() {
   return txb;
 }
 
+function opEncode(opcode) {
+  // NOTE: must *always* a 3-character string
+  var res = '' + _config.config.network.MAGIC_BYTES + opcode;
+  if (res.length !== 3) {
+    throw new Error('Runtime error: invalid MAGIC_BYTES');
+  }
+  return res;
+}
+
 function makePreorderSkeleton(fullyQualifiedName, consensusHash, preorderAddress, burnAddress, burn) {
   var registerAddress = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : null;
 
@@ -213,7 +222,7 @@ function makePreorderSkeleton(fullyQualifiedName, consensusHash, preorderAddress
 
   var opReturnBufferLen = burnAmount.units === 'BTC' ? 39 : 66;
   var opReturnBuffer = Buffer.alloc(opReturnBufferLen);
-  opReturnBuffer.write('id?', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('?'), 0, 3, 'ascii');
   hashed.copy(opReturnBuffer, 3);
   opReturnBuffer.write(consensusHash, 23, 16, 'hex');
 
@@ -301,7 +310,7 @@ function makeRegisterSkeleton(fullyQualifiedName, ownerAddress) {
     payload = Buffer.from(fullyQualifiedName, 'ascii');
   }
 
-  var opReturnBuffer = Buffer.concat([Buffer.from('id:', 'ascii'), payload]);
+  var opReturnBuffer = Buffer.concat([Buffer.from(opEncode(':'), 'ascii'), payload]);
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
   var tx = makeTXbuilder();
 
@@ -382,7 +391,7 @@ function makeTransferSkeleton(fullyQualifiedName, consensusHash, newOwner) {
     keepChar = '>';
   }
 
-  opRet.write('id>', 0, 3, 'ascii');
+  opRet.write(opEncode('>'), 0, 3, 'ascii');
   opRet.write(keepChar, 3, 1, 'ascii');
 
   var hashed = (0, _utils.hash128)(Buffer.from(fullyQualifiedName, 'ascii'));
@@ -423,7 +432,7 @@ function makeUpdateSkeleton(fullyQualifiedName, consensusHash, valueHash) {
 
   var hashedName = (0, _utils.hash128)(Buffer.concat([nameBuff, consensusBuff]));
 
-  opRet.write('id+', 0, 3, 'ascii');
+  opRet.write(opEncode('+'), 0, 3, 'ascii');
   hashedName.copy(opRet, 3);
   opRet.write(valueHash, 19, 20, 'hex');
 
@@ -455,7 +464,7 @@ function makeRevokeSkeleton(fullyQualifiedName) {
 
   var nameBuff = Buffer.from(fullyQualifiedName, 'ascii');
 
-  opRet.write('id~', 0, 3, 'ascii');
+  opRet.write(opEncode('~'), 0, 3, 'ascii');
 
   var opReturnBuffer = Buffer.concat([opRet, nameBuff]);
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -509,7 +518,7 @@ function makeNamespacePreorderSkeleton(namespaceID, consensusHash, preorderAddre
   }
 
   var opReturnBuffer = Buffer.alloc(opReturnBufferLen);
-  opReturnBuffer.write('id*', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('*'), 0, 3, 'ascii');
   hashed.copy(opReturnBuffer, 3);
   opReturnBuffer.write(consensusHash, 23, 16, 'hex');
 
@@ -544,7 +553,7 @@ function makeNamespaceRevealSkeleton(namespace, revealAddress) {
   var hexPayload = namespace.toHexPayload();
 
   var opReturnBuffer = Buffer.alloc(3 + hexPayload.length / 2);
-  opReturnBuffer.write('id&', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('&'), 0, 3, 'ascii');
   opReturnBuffer.write(hexPayload, 3, hexPayload.length / 2, 'hex');
 
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -565,7 +574,7 @@ function makeNamespaceReadySkeleton(namespaceID) {
     output 0: namespace ready code
    */
   var opReturnBuffer = Buffer.alloc(3 + namespaceID.length + 1);
-  opReturnBuffer.write('id!', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('!'), 0, 3, 'ascii');
   opReturnBuffer.write('.' + namespaceID, 3, namespaceID.length + 1, 'ascii');
 
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -592,7 +601,7 @@ function makeNameImportSkeleton(name, recipientAddr, zonefileHash) {
 
   var network = _config.config.network;
   var opReturnBuffer = Buffer.alloc(3 + name.length);
-  opReturnBuffer.write('id;', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode(';'), 0, 3, 'ascii');
   opReturnBuffer.write(name, 3, name.length, 'ascii');
 
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -620,7 +629,7 @@ function makeAnnounceSkeleton(messageHash) {
   }
 
   var opReturnBuffer = Buffer.alloc(3 + messageHash.length / 2);
-  opReturnBuffer.write('id#', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('#'), 0, 3, 'ascii');
   opReturnBuffer.write(messageHash, 3, messageHash.length / 2, 'hex');
 
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -658,7 +667,7 @@ function makeTokenTransferSkeleton(recipientAddress, consensusHash, tokenType, t
 
   var tokenValueHexPadded = ('0000000000000000' + tokenValueHex).slice(-16);
 
-  opReturnBuffer.write('id$', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('$'), 0, 3, 'ascii');
   opReturnBuffer.write(consensusHash, 3, consensusHash.length / 2, 'hex');
   opReturnBuffer.write(tokenTypeHexPadded, 19, tokenTypeHexPadded.length / 2, 'hex');
   opReturnBuffer.write(tokenValueHexPadded, 38, tokenValueHexPadded.length / 2, 'hex');

--- a/node_modules/blockstack/lib/storage/hub.js
+++ b/node_modules/blockstack/lib/storage/hub.js
@@ -47,7 +47,11 @@ function uploadToGaiaHub(filename, contents, hubConfig) {
     },
     body: contents
   }).then(function (response) {
-    return response.text();
+    if (response.ok) {
+      return response.text();
+    } else {
+      throw new Error('Error when uploading to Gaia hub');
+    }
   }).then(function (responseText) {
     return JSON.parse(responseText);
   }).then(function (responseJSON) {

--- a/node_modules/blockstack/lib/storage/index.js
+++ b/node_modules/blockstack/lib/storage/index.js
@@ -389,7 +389,13 @@ function putFile(path, content, options) {
     var signatureObject = (0, _encryption.signECDSA)(privateKey, content);
     var signatureContent = JSON.stringify(signatureObject);
     return (0, _hub.getOrSetLocalGaiaHubConnection)().then(function (gaiaHubConfig) {
-      return Promise.all([(0, _hub.uploadToGaiaHub)(path, content, gaiaHubConfig, contentType), (0, _hub.uploadToGaiaHub)('' + path + SIGNATURE_FILE_SUFFIX, signatureContent, gaiaHubConfig, 'application/json')]);
+      return new Promise(function (resolve, reject) {
+        return Promise.all([(0, _hub.uploadToGaiaHub)(path, content, gaiaHubConfig, contentType), (0, _hub.uploadToGaiaHub)('' + path + SIGNATURE_FILE_SUFFIX, signatureContent, gaiaHubConfig, 'application/json')]).then(resolve).catch(function () {
+          (0, _hub.setLocalGaiaHubConnection)().then(function (freshHubConfig) {
+            return Promise.all([(0, _hub.uploadToGaiaHub)(path, content, freshHubConfig, contentType), (0, _hub.uploadToGaiaHub)('' + path + SIGNATURE_FILE_SUFFIX, signatureContent, freshHubConfig, 'application/json')]).then(resolve).catch(reject);
+          });
+        });
+      });
     }).then(function (fileUrls) {
       return fileUrls[0];
     });
@@ -411,7 +417,13 @@ function putFile(path, content, options) {
     contentType = 'application/json';
   }
   return (0, _hub.getOrSetLocalGaiaHubConnection)().then(function (gaiaHubConfig) {
-    return (0, _hub.uploadToGaiaHub)(path, content, gaiaHubConfig, contentType);
+    return new Promise(function (resolve, reject) {
+      (0, _hub.uploadToGaiaHub)(path, content, gaiaHubConfig, contentType).then(resolve).catch(function () {
+        (0, _hub.setLocalGaiaHubConnection)().then(function (freshHubConfig) {
+          return (0, _hub.uploadToGaiaHub)(path, content, freshHubConfig, contentType).then(resolve).catch(reject);
+        });
+      });
+    });
   });
 }
 
@@ -497,7 +509,7 @@ function listFilesLoop(hubConfig, page, callCount, fileCount, callback) {
       return listFilesLoop(hubConfig, nextPage, callCount + 1, fileCount + entries.length, callback);
     } else {
       // no more entries -- end of data
-      return Promise.resolve(fileCount);
+      return Promise.resolve(fileCount + entries.length);
     }
   });
 }

--- a/node_modules/blockstack/package.json
+++ b/node_modules/blockstack/package.json
@@ -1,8 +1,8 @@
 {
-  "_from": "blockstack@^18.1.0",
-  "_id": "blockstack@18.2.0",
+  "_from": "blockstack@^18.2.1",
+  "_id": "blockstack@18.2.1",
   "_inBundle": false,
-  "_integrity": "sha512-9Dvykec9Qs71lqYH089+dkzIHSkvb2YMRiOUW9iuuwGPh461kvn6HL99yBCQyrOng9xfdc+DBHrxGRRv8J+rDg==",
+  "_integrity": "sha512-hcJdNhltNSRZg6iouSauWOzKpVnfC1NFIMBhC9sZjaIFCPIojDrgvRcgoh3AEy8LMkj1krr26AKAOhnRcQJmng==",
   "_location": "/blockstack",
   "_phantomChildren": {
     "asap": "2.0.6",
@@ -29,20 +29,20 @@
   "_requested": {
     "type": "range",
     "registry": true,
-    "raw": "blockstack@^18.1.0",
+    "raw": "blockstack@^18.2.1",
     "name": "blockstack",
     "escapedName": "blockstack",
-    "rawSpec": "^18.1.0",
+    "rawSpec": "^18.2.1",
     "saveSpec": null,
-    "fetchSpec": "^18.1.0"
+    "fetchSpec": "^18.2.1"
   },
   "_requiredBy": [
     "/"
   ],
-  "_resolved": "https://registry.npmjs.org/blockstack/-/blockstack-18.2.0.tgz",
-  "_shasum": "c206822f78ea16bea756ce7dd88842b01a8437a3",
-  "_spec": "blockstack@^18.1.0",
-  "_where": "/Users/slideroom/Documents/GitHub/graphite-publishing",
+  "_resolved": "https://registry.npmjs.org/blockstack/-/blockstack-18.2.1.tgz",
+  "_shasum": "e369a189107f585093ce852a9a9e3514076d5cc5",
+  "_spec": "blockstack@^18.2.1",
+  "_where": "/Users/hank/blockstack/built-apps/graphite-publishing",
   "author": {
     "name": "Blockstack PBC",
     "email": "admin@blockstack.com",
@@ -185,5 +185,5 @@
     "test": "nyc --reporter=text npm run unit-test",
     "unit-test": "npm run lint && npm run flow && npm run compile && npm run compile-tests && npm run browserify && node ./tests/unitTests/lib/index.js"
   },
-  "version": "18.2.0"
+  "version": "18.2.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1525,7 +1525,7 @@
         },
         "create-hash": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
           "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
           "requires": {
             "cipher-base": "^1.0.1",
@@ -1537,7 +1537,7 @@
         },
         "create-hmac": {
           "version": "1.1.7",
-          "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
           "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
           "requires": {
             "cipher-base": "^1.0.3",
@@ -1643,9 +1643,9 @@
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
     },
     "blockstack": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/blockstack/-/blockstack-18.2.0.tgz",
-      "integrity": "sha512-9Dvykec9Qs71lqYH089+dkzIHSkvb2YMRiOUW9iuuwGPh461kvn6HL99yBCQyrOng9xfdc+DBHrxGRRv8J+rDg==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/blockstack/-/blockstack-18.2.1.tgz",
+      "integrity": "sha512-hcJdNhltNSRZg6iouSauWOzKpVnfC1NFIMBhC9sZjaIFCPIojDrgvRcgoh3AEy8LMkj1krr26AKAOhnRcQJmng==",
       "requires": {
         "ajv": "^4.11.5",
         "babel-runtime": "^6.26.0",
@@ -3129,12 +3129,12 @@
       "dependencies": {
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
         },
         "whatwg-fetch": {
           "version": "2.0.4",
-          "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
           "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
         }
       }
@@ -22596,7 +22596,7 @@
         },
         "create-hmac": {
           "version": "1.1.7",
-          "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
           "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
           "requires": {
             "cipher-base": "^1.0.3",
@@ -22758,7 +22758,7 @@
       "dependencies": {
         "progress": {
           "version": "1.1.8",
-          "resolved": "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
           "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
         }
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-loader": "7.1.2",
     "babel-preset-react-app": "^3.1.1",
     "babel-runtime": "6.26.0",
-    "blockstack": "^18.1.0",
+    "blockstack": "^18.2.1",
     "blockstack-large-storage": "0.0.2",
     "bootstrap": "^3.3.7",
     "bower": "^1.8.2",


### PR DESCRIPTION
Hey there!

We recently upgraded blockstack.js to gracefully handle failures in the case of Gaia tokens being invalidated. With this upgrade, if Gaia tokens are ever invalidated, `blockstack.js` will automatically generate a new token and retry a write to Gaia.

Without this change, all writes will fail until the user logs out and back in.

I think this upgrade is rather important, so that your app can gracefully handle Gaia authentication errors due to token invalidations.

Hope all is well,

Hank